### PR TITLE
fix: fix incorrect call to ultrahtml html function

### DIFF
--- a/.changeset/lazy-chicken-carry.md
+++ b/.changeset/lazy-chicken-carry.md
@@ -1,0 +1,5 @@
+---
+"satori-html": patch
+---
+
+Fixes an incorrect internal call to `ultrahtml`'s `html` function

--- a/packages/satori-html/src/index.ts
+++ b/packages/satori-html/src/index.ts
@@ -81,7 +81,11 @@ export function html(
   templates: string | TemplateStringsArray,
   ...expressions: any[]
 ): VNode {
-  const result = __html.call(null, templates, ...expressions);
+  const result = __html.call(
+    null,
+    typeof templates === "string" ? [templates] : templates,
+    ...expressions
+  );
   let doc = parse(result.value.trim());
   inliner(doc);
   tw(doc);


### PR DESCRIPTION
This PR fixes an incorrect call to the `html` function of `ultrahtml`. This results in a severe performance degradation, because the entire string is being traversed without doing any substitutions on the string itself.